### PR TITLE
Integrate LocalLLM into Agent for on-device inference

### DIFF
--- a/src/pci_agent/agent.py
+++ b/src/pci_agent/agent.py
@@ -135,6 +135,8 @@ class Agent:
         """Cleanup resources"""
         await self._context_client.disconnect()
         if self._llm is not None:
-            await self._llm.unload()
-            self._llm = None
+            try:
+                await self._llm.unload()
+            finally:
+                self._llm = None
         self._initialized = False

--- a/src/pci_agent/agent.py
+++ b/src/pci_agent/agent.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from pci_agent.config import AgentConfig
-from pci_agent.context import ContextClient
+from pci_agent.context import ContextClient, ContextItem
+from pci_agent.models.local_llm import LocalLLM
 from pci_agent.policy import PolicyChecker
 
 
@@ -30,7 +31,7 @@ class Agent:
 
     def __init__(self, config: AgentConfig | None = None) -> None:
         self.config = config or AgentConfig()
-        self._llm: object | None = None
+        self._llm: LocalLLM | None = None
         self._context_client = ContextClient(self.config.context)
         self._policy_checker = PolicyChecker()
         self._initialized = False
@@ -97,28 +98,43 @@ class Agent:
             timestamp=datetime.now(),
         )
 
-    async def _load_llm(self) -> object:
+    async def _load_llm(self) -> LocalLLM:
         """Load the local language model"""
-        # TODO: Integrate with llama-cpp-python
-        # This is a placeholder for the actual implementation
-        return None
+        llm = LocalLLM(self.config.llm)
+        await llm.load()
+        return llm
 
     async def _generate_response(
         self,
         query: str,
-        context_items: list,
+        context_items: list[ContextItem],
     ) -> str:
         """Generate a response using the LLM"""
         if self._llm is None:
-            # Fallback when no LLM is loaded
             context_summary = ", ".join(item.id for item in context_items)
             return f"[No LLM loaded] Query: {query}, Context: {context_summary}"
 
-        # TODO: Implement actual LLM inference
-        return f"Response to: {query}"
+        prompt = self._build_prompt(query, context_items)
+        response = await self._llm.generate(prompt)
+        return response.text
+
+    @staticmethod
+    def _build_prompt(query: str, context_items: list[ContextItem]) -> str:
+        """Build a prompt from the query and retrieved context"""
+        parts: list[str] = []
+        if context_items:
+            parts.append("Context:")
+            for item in context_items:
+                parts.append(f"- {item.content}")
+            parts.append("")
+        parts.append(f"Question: {query}")
+        parts.append("Answer:")
+        return "\n".join(parts)
 
     async def close(self) -> None:
         """Cleanup resources"""
         await self._context_client.disconnect()
-        self._llm = None
+        if self._llm is not None:
+            await self._llm.unload()
+            self._llm = None
         self._initialized = False

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,8 +1,13 @@
 """Tests for the PCI Agent"""
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 from pci_agent import Agent, AgentConfig
+from pci_agent.config import LLMConfig
+from pci_agent.context import ContextItem
+from pci_agent.models.local_llm import LLMResponse, LocalLLM
 from pci_agent.policy import PolicyChecker
 
 
@@ -29,6 +34,107 @@ class TestAgent:
         await agent.initialize()
         await agent.close()
         assert agent._initialized is False
+
+    async def test_no_llm_without_model_path(self, agent: Agent) -> None:
+        """Test that no LLM is loaded when model_path is not set"""
+        await agent.initialize()
+        assert agent._llm is None
+
+    async def test_fallback_response_without_llm(self, agent: Agent) -> None:
+        """Test that agent returns fallback response when no LLM loaded"""
+        response = await agent.process("Hello")
+        assert "[No LLM loaded]" in response.content
+        assert "Hello" in response.content
+
+
+class TestAgentWithLLM:
+    """Tests for the Agent class with LLM integration"""
+
+    @pytest.fixture
+    def llm_config(self) -> AgentConfig:
+        return AgentConfig(
+            llm=LLMConfig(
+                model_path="/tmp/test-model.gguf",
+                context_length=2048,
+                n_gpu_layers=0,
+            )
+        )
+
+    async def test_llm_loaded_when_model_path_set(self, llm_config: AgentConfig) -> None:
+        """Test that LocalLLM is instantiated and loaded when model_path is configured"""
+        agent = Agent(llm_config)
+
+        with patch.object(LocalLLM, "load", new_callable=AsyncMock) as mock_load:
+            await agent.initialize()
+
+            mock_load.assert_called_once()
+            assert agent._llm is not None
+            assert isinstance(agent._llm, LocalLLM)
+            assert agent._llm.config.model_path == "/tmp/test-model.gguf"
+
+    async def test_generate_response_calls_llm(self, llm_config: AgentConfig) -> None:
+        """Test that _generate_response uses the LLM when loaded"""
+        agent = Agent(llm_config)
+
+        mock_response = LLMResponse(text="Generated answer", tokens_used=42, finish_reason="stop")
+
+        with patch.object(LocalLLM, "load", new_callable=AsyncMock):
+            await agent.initialize()
+
+        with patch.object(agent._llm, "generate", new_callable=AsyncMock) as mock_gen:  # type: ignore[union-attr]
+            mock_gen.return_value = mock_response
+            response = await agent.process("What is 2+2?")
+
+            mock_gen.assert_called_once()
+            assert response.content == "Generated answer"
+
+    async def test_prompt_includes_context(self) -> None:
+        """Test that _build_prompt incorporates context items"""
+        context_items = [
+            ContextItem(id="1", content="The sky is blue", score=0.9),
+            ContextItem(id="2", content="Water is wet", score=0.8),
+        ]
+        prompt = Agent._build_prompt("Why is the sky blue?", context_items)
+
+        assert "Context:" in prompt
+        assert "- The sky is blue" in prompt
+        assert "- Water is wet" in prompt
+        assert "Question: Why is the sky blue?" in prompt
+        assert "Answer:" in prompt
+
+    async def test_prompt_without_context(self) -> None:
+        """Test that _build_prompt works without context items"""
+        prompt = Agent._build_prompt("Hello", [])
+
+        assert "Context:" not in prompt
+        assert "Question: Hello" in prompt
+        assert "Answer:" in prompt
+
+    async def test_close_unloads_llm(self, llm_config: AgentConfig) -> None:
+        """Test that close() calls unload on the LLM"""
+        agent = Agent(llm_config)
+
+        with patch.object(LocalLLM, "load", new_callable=AsyncMock):
+            await agent.initialize()
+
+        with patch.object(agent._llm, "unload", new_callable=AsyncMock) as mock_unload:  # type: ignore[union-attr]
+            await agent.close()
+
+            mock_unload.assert_called_once()
+            assert agent._llm is None
+            assert agent._initialized is False
+
+    async def test_llm_import_error_propagates(self, llm_config: AgentConfig) -> None:
+        """Test that ImportError from missing llama-cpp-python propagates"""
+        agent = Agent(llm_config)
+
+        with patch.object(
+            LocalLLM,
+            "load",
+            new_callable=AsyncMock,
+            side_effect=ImportError("llama-cpp-python not installed"),
+        ), pytest.raises(ImportError, match="llama-cpp-python"):
+            await agent.initialize()
 
 
 class TestPolicyChecker:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,5 +1,6 @@
 """Tests for the PCI Agent"""
 
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -51,10 +52,10 @@ class TestAgentWithLLM:
     """Tests for the Agent class with LLM integration"""
 
     @pytest.fixture
-    def llm_config(self) -> AgentConfig:
+    def llm_config(self, tmp_path: Path) -> AgentConfig:
         return AgentConfig(
             llm=LLMConfig(
-                model_path="/tmp/test-model.gguf",
+                model_path=str(tmp_path / "test-model.gguf"),
                 context_length=2048,
                 n_gpu_layers=0,
             )
@@ -70,7 +71,8 @@ class TestAgentWithLLM:
             mock_load.assert_called_once()
             assert agent._llm is not None
             assert isinstance(agent._llm, LocalLLM)
-            assert agent._llm.config.model_path == "/tmp/test-model.gguf"
+            assert agent._llm.config.model_path is not None
+            assert agent._llm.config.model_path.endswith("test-model.gguf")
 
     async def test_generate_response_calls_llm(self, llm_config: AgentConfig) -> None:
         """Test that _generate_response uses the LLM when loaded"""
@@ -86,6 +88,8 @@ class TestAgentWithLLM:
             response = await agent.process("What is 2+2?")
 
             mock_gen.assert_called_once()
+            prompt_arg = mock_gen.call_args.args[0]
+            assert "Question: What is 2+2?" in prompt_arg
             assert response.content == "Generated answer"
 
     async def test_prompt_includes_context(self) -> None:


### PR DESCRIPTION
## Summary
- Wires the existing `LocalLLM` class (llama-cpp-python) into `Agent._load_llm()` so a GGUF model is loaded when `model_path` is configured
- Implements `_generate_response()` to build prompts from query + retrieved context and call the model for inference
- Adds proper `unload()` cleanup in `Agent.close()`
- Adds 8 new tests (14 total) covering LLM loading, generation, prompt building, cleanup, and error propagation

## Test plan
- [x] All 14 tests pass (`uv run pytest tests/ -v`)
- [x] Ruff lint clean
- [x] mypy clean on changed files (pre-existing errors in other files unchanged)
- [ ] Manual test with a real GGUF model file (e.g. Phi-3-mini) to verify end-to-end inference

Closes #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent now generates responses using the configured language model.

* **Bug Fixes**
  * Agent gracefully handles scenarios where no language model is configured, returning an informative fallback message.

* **Refactor**
  * Improved resource management and lifecycle handling for language model instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->