### PR TITLE
chore: ignore local Claude Code / pragma config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,9 @@ Thumbs.db
 models/
 *.gguf
 *.bin
+
+# Claude Code / pragma (keep local, do not commit)
+CLAUDE.local.md
+CLAUDE.md
+AGENTS.md
+.claude/


### PR DESCRIPTION
## Summary

Add local agent-tooling config to `.gitignore` so it stays per-developer and is not committed to the repo:

- `CLAUDE.local.md`
- `CLAUDE.md`
- `AGENTS.md`
- `.claude/`

## Why

These files are generated locally by developer tooling and are personal/machine-specific. Keeping them out of version control avoids noise and keeps the repo tooling-agnostic.

## Changes

- `.gitignore`: new "Claude Code / pragma (keep local, do not commit)" section.