### PR TITLE
Port legacy coordination endpoints (/services, /service-requests) to FastAPI

### DIFF
--- a/src/pci_agent/api.py
+++ b/src/pci_agent/api.py
@@ -22,6 +22,8 @@ from pci_agent.coordination import (
     ApprovalDecision,
     ApprovalMode,
     RequestStatus,
+    ServiceRequest,
+    ServiceRequestStatus,
     VerificationClaim,
     VerificationRequest,
 )
@@ -31,16 +33,23 @@ from pci_agent.seams import (
     DeterministicContextBuilder,
 )
 from pci_agent.services.approval import ApprovalService, resolved_status_for, status_for
-from pci_agent.store import RequestRepository
+from pci_agent.services.service_requests import LINKABLE_STATUSES, service_status_for
+from pci_agent.status import ServicesStatus, StatusClient
+from pci_agent.store import RequestRepository, ServiceRequestRepository
 from pci_agent.zkp import ZKPClient
 
 ZKP_SERVICE_URL = os.environ.get("ZKP_SERVICE_URL", "http://localhost:8084")
+CARDANO_API_URL = os.environ.get("CARDANO_API_URL", "http://localhost:8080")
 
 
 class _Decider(Protocol):
     async def decide(self, request: VerificationRequest) -> ApprovalDecision: ...
 
     async def approve(self, request: VerificationRequest) -> ApprovalDecision: ...
+
+
+class _StatusSource(Protocol):
+    async def check(self) -> ServicesStatus: ...
 
 
 class CreateVerificationRequest(BaseModel):
@@ -52,6 +61,16 @@ class CreateVerificationRequest(BaseModel):
     policy_id: str | None = None
     context_scope: str | None = None
     service_request_id: str | None = None
+
+
+class CreateServiceRequest(BaseModel):
+    """Inbound payload for POST /service-requests."""
+
+    user_id: str
+    user_name: str
+    business_id: str
+    service_type: str
+    service_name: str
 
 
 def _default_service_factory(config: AgentConfig, zkp_client: ZKPClient) -> Callable[[], _Decider]:
@@ -71,6 +90,8 @@ def create_app(
     *,
     service_factory: Callable[[], _Decider] | None = None,
     repository: RequestRepository | None = None,
+    service_request_repository: ServiceRequestRepository | None = None,
+    status_source: _StatusSource | None = None,
 ) -> FastAPI:
     """Build the coordination app.
 
@@ -80,12 +101,17 @@ def create_app(
             omitted, one shared ZKPClient is created for the app's lifetime and
             closed on shutdown.
         repository: Request store (injected in tests).
+        service_request_repository: Service-request store (injected in tests).
+        status_source: Provides the /services aggregate (injected in tests).
+            When omitted, one shared StatusClient is created for the app's
+            lifetime and closed on shutdown.
 
     Returns:
         The configured FastAPI application.
     """
     config = config or AgentConfig()
     repo = repository or RequestRepository()
+    service_repo = service_request_repository or ServiceRequestRepository()
 
     # A single ZKPClient owns one connection pool for the app's lifetime; the
     # per-request service is otherwise cheap to rebuild. Tests inject their own
@@ -97,14 +123,26 @@ def create_app(
     else:
         make_service = service_factory
 
+    status_client: StatusClient | None = None
+    if status_source is None:
+        agent_url = f"http://localhost:{os.environ.get('PORT', '8082')}"
+        status_client = StatusClient(
+            agent_url=agent_url, zkp_url=ZKP_SERVICE_URL, cardano_url=CARDANO_API_URL
+        )
+        status_checker: _StatusSource = status_client
+    else:
+        status_checker = status_source
+
     @asynccontextmanager
     async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
-        """Close the shared ZKP client's connection pool on shutdown."""
+        """Close the shared HTTP clients' connection pools on shutdown."""
         try:
             yield
         finally:
             if zkp_client is not None:
                 await zkp_client.aclose()
+            if status_client is not None:
+                await status_client.aclose()
 
     app = FastAPI(title="pci-agent", version="0.1.0", lifespan=lifespan)
 
@@ -126,6 +164,45 @@ def create_app(
             raise HTTPException(status_code=404, detail="request not found")
         return req
 
+    def _link_service_request(req: VerificationRequest) -> None:
+        """Attach a new verification request to its service request, if any.
+
+        Raises:
+            HTTPException: 404 if the referenced service request is not
+                tracked, 409 if it has already been resolved.
+        """
+        if req.service_request_id is None:
+            return
+        service_req = service_repo.get(req.service_request_id)
+        if service_req is None:
+            raise HTTPException(status_code=404, detail="service request not found")
+        if service_req.status not in LINKABLE_STATUSES:
+            raise HTTPException(status_code=409, detail="service request already resolved")
+        service_repo.replace(
+            service_req.model_copy(
+                update={
+                    "status": ServiceRequestStatus.VERIFICATION_REQUIRED,
+                    "verification_request_id": req.id,
+                }
+            )
+        )
+
+    def _sync_service_request(req: VerificationRequest) -> None:
+        """Propagate a verification outcome to the linked service request.
+
+        Only the verification request the service request currently links to
+        may drive it; a stale, re-requested verification is ignored.
+        """
+        if req.service_request_id is None:
+            return
+        service_req = service_repo.get(req.service_request_id)
+        if service_req is None or service_req.verification_request_id != req.id:
+            return
+        new_status = service_status_for(req.status)
+        if new_status is None or service_req.status is new_status:
+            return
+        service_repo.replace(service_req.model_copy(update={"status": new_status}))
+
     @app.post("/requests", status_code=201)
     async def create_request(payload: CreateVerificationRequest) -> VerificationRequest:
         """Create a request; autonomously resolve it unless in manual mode."""
@@ -141,6 +218,7 @@ def create_app(
             created_at=now,
             expires_at=now + timedelta(minutes=5),
         )
+        _link_service_request(req)
         if config.approval.mode is not ApprovalMode.MANUAL:
             try:
                 decision = await make_service().decide(req)
@@ -154,6 +232,7 @@ def create_app(
                 }
             )
         repo.add(req)
+        _sync_service_request(req)
         return req
 
     @app.post("/requests/{request_id}/approve")
@@ -177,6 +256,7 @@ def create_app(
             }
         )
         repo.replace(req)
+        _sync_service_request(req)
         return req
 
     @app.post("/requests/{request_id}/deny")
@@ -195,7 +275,71 @@ def create_app(
             }
         )
         repo.replace(req)
+        _sync_service_request(req)
         return req
+
+    @app.get("/services")
+    async def services_status() -> ServicesStatus:
+        """Report reachability of the agent and its coordinated services."""
+        return await status_checker.check()
+
+    @app.get("/service-requests")
+    async def list_service_requests(
+        status: ServiceRequestStatus | None = None,
+    ) -> dict[str, list[ServiceRequest]]:
+        """Return tracked service requests, optionally filtered by status."""
+        requests = service_repo.list()
+        if status is not None:
+            requests = [r for r in requests if r.status is status]
+        return {"requests": requests}
+
+    @app.get("/service-requests/{request_id}")
+    async def get_service_request(request_id: str) -> ServiceRequest:
+        """Return a single service request, or 404 if it is not tracked."""
+        service_req = service_repo.get(request_id)
+        if service_req is None:
+            raise HTTPException(status_code=404, detail="service request not found")
+        return service_req
+
+    @app.post("/service-requests", status_code=201)
+    async def create_service_request(payload: CreateServiceRequest) -> ServiceRequest:
+        """Create a pending service request for the business to pick up."""
+        now = datetime.now(UTC)
+        service_req = ServiceRequest(
+            id=uuid.uuid4().hex,
+            user_id=payload.user_id,
+            user_name=payload.user_name,
+            business_id=payload.business_id,
+            service_type=payload.service_type,
+            service_name=payload.service_name,
+            created_at=now,
+            expires_at=now + timedelta(minutes=10),
+        )
+        service_repo.add(service_req)
+        return service_req
+
+    @app.post("/service-requests/{request_id}/complete")
+    async def complete_service_request(request_id: str) -> ServiceRequest:
+        """Complete a verified service request.
+
+        Completing an already-completed request is idempotent and returns the
+        request unchanged with 200; any other unverified state is a 409.
+        """
+        service_req = service_repo.get(request_id)
+        if service_req is None:
+            raise HTTPException(status_code=404, detail="service request not found")
+        if service_req.status is ServiceRequestStatus.COMPLETED:
+            return service_req
+        if service_req.status is not ServiceRequestStatus.VERIFIED:
+            raise HTTPException(status_code=409, detail="service request not verified")
+        service_req = service_req.model_copy(
+            update={
+                "status": ServiceRequestStatus.COMPLETED,
+                "completed_at": datetime.now(UTC),
+            }
+        )
+        service_repo.replace(service_req)
+        return service_req
 
     return app
 

--- a/src/pci_agent/api.py
+++ b/src/pci_agent/api.py
@@ -21,19 +21,21 @@ from pci_agent.context import ContextClient
 from pci_agent.coordination import (
     ApprovalDecision,
     ApprovalMode,
+    CreateServiceRequest,
     RequestStatus,
     ServiceRequest,
     ServiceRequestStatus,
     VerificationClaim,
     VerificationRequest,
 )
+from pci_agent.errors import ServiceRequestConflict, ServiceRequestNotFound
 from pci_agent.policy import PolicyChecker
 from pci_agent.seams import (
     ContextStoreDataProvider,
     DeterministicContextBuilder,
 )
+from pci_agent.services import service_requests
 from pci_agent.services.approval import ApprovalService, resolved_status_for, status_for
-from pci_agent.services.service_requests import LINKABLE_STATUSES, service_status_for
 from pci_agent.status import ServicesStatus, StatusClient
 from pci_agent.store import RequestRepository, ServiceRequestRepository
 from pci_agent.zkp import ZKPClient
@@ -61,16 +63,6 @@ class CreateVerificationRequest(BaseModel):
     policy_id: str | None = None
     context_scope: str | None = None
     service_request_id: str | None = None
-
-
-class CreateServiceRequest(BaseModel):
-    """Inbound payload for POST /service-requests."""
-
-    user_id: str
-    user_name: str
-    business_id: str
-    service_type: str
-    service_name: str
 
 
 def _default_service_factory(config: AgentConfig, zkp_client: ZKPClient) -> Callable[[], _Decider]:
@@ -139,10 +131,12 @@ def create_app(
         try:
             yield
         finally:
-            if zkp_client is not None:
-                await zkp_client.aclose()
-            if status_client is not None:
-                await status_client.aclose()
+            try:
+                if zkp_client is not None:
+                    await zkp_client.aclose()
+            finally:
+                if status_client is not None:
+                    await status_client.aclose()
 
     app = FastAPI(title="pci-agent", version="0.1.0", lifespan=lifespan)
 
@@ -164,45 +158,6 @@ def create_app(
             raise HTTPException(status_code=404, detail="request not found")
         return req
 
-    def _link_service_request(req: VerificationRequest) -> None:
-        """Attach a new verification request to its service request, if any.
-
-        Raises:
-            HTTPException: 404 if the referenced service request is not
-                tracked, 409 if it has already been resolved.
-        """
-        if req.service_request_id is None:
-            return
-        service_req = service_repo.get(req.service_request_id)
-        if service_req is None:
-            raise HTTPException(status_code=404, detail="service request not found")
-        if service_req.status not in LINKABLE_STATUSES:
-            raise HTTPException(status_code=409, detail="service request already resolved")
-        service_repo.replace(
-            service_req.model_copy(
-                update={
-                    "status": ServiceRequestStatus.VERIFICATION_REQUIRED,
-                    "verification_request_id": req.id,
-                }
-            )
-        )
-
-    def _sync_service_request(req: VerificationRequest) -> None:
-        """Propagate a verification outcome to the linked service request.
-
-        Only the verification request the service request currently links to
-        may drive it; a stale, re-requested verification is ignored.
-        """
-        if req.service_request_id is None:
-            return
-        service_req = service_repo.get(req.service_request_id)
-        if service_req is None or service_req.verification_request_id != req.id:
-            return
-        new_status = service_status_for(req.status)
-        if new_status is None or service_req.status is new_status:
-            return
-        service_repo.replace(service_req.model_copy(update={"status": new_status}))
-
     @app.post("/requests", status_code=201)
     async def create_request(payload: CreateVerificationRequest) -> VerificationRequest:
         """Create a request; autonomously resolve it unless in manual mode."""
@@ -218,7 +173,12 @@ def create_app(
             created_at=now,
             expires_at=now + timedelta(minutes=5),
         )
-        _link_service_request(req)
+        try:
+            service_requests.link_verification(service_repo, req)
+        except ServiceRequestNotFound as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except ServiceRequestConflict as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
         if config.approval.mode is not ApprovalMode.MANUAL:
             try:
                 decision = await make_service().decide(req)
@@ -232,7 +192,7 @@ def create_app(
                 }
             )
         repo.add(req)
-        _sync_service_request(req)
+        service_requests.apply_verification_outcome(service_repo, req)
         return req
 
     @app.post("/requests/{request_id}/approve")
@@ -256,7 +216,7 @@ def create_app(
             }
         )
         repo.replace(req)
-        _sync_service_request(req)
+        service_requests.apply_verification_outcome(service_repo, req)
         return req
 
     @app.post("/requests/{request_id}/deny")
@@ -275,7 +235,7 @@ def create_app(
             }
         )
         repo.replace(req)
-        _sync_service_request(req)
+        service_requests.apply_verification_outcome(service_repo, req)
         return req
 
     @app.get("/services")
@@ -304,19 +264,7 @@ def create_app(
     @app.post("/service-requests", status_code=201)
     async def create_service_request(payload: CreateServiceRequest) -> ServiceRequest:
         """Create a pending service request for the business to pick up."""
-        now = datetime.now(UTC)
-        service_req = ServiceRequest(
-            id=uuid.uuid4().hex,
-            user_id=payload.user_id,
-            user_name=payload.user_name,
-            business_id=payload.business_id,
-            service_type=payload.service_type,
-            service_name=payload.service_name,
-            created_at=now,
-            expires_at=now + timedelta(minutes=10),
-        )
-        service_repo.add(service_req)
-        return service_req
+        return service_requests.create(service_repo, payload)
 
     @app.post("/service-requests/{request_id}/complete")
     async def complete_service_request(request_id: str) -> ServiceRequest:
@@ -325,21 +273,12 @@ def create_app(
         Completing an already-completed request is idempotent and returns the
         request unchanged with 200; any other unverified state is a 409.
         """
-        service_req = service_repo.get(request_id)
-        if service_req is None:
-            raise HTTPException(status_code=404, detail="service request not found")
-        if service_req.status is ServiceRequestStatus.COMPLETED:
-            return service_req
-        if service_req.status is not ServiceRequestStatus.VERIFIED:
-            raise HTTPException(status_code=409, detail="service request not verified")
-        service_req = service_req.model_copy(
-            update={
-                "status": ServiceRequestStatus.COMPLETED,
-                "completed_at": datetime.now(UTC),
-            }
-        )
-        service_repo.replace(service_req)
-        return service_req
+        try:
+            return service_requests.complete(service_repo, request_id)
+        except ServiceRequestNotFound as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except ServiceRequestConflict as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
 
     return app
 

--- a/src/pci_agent/coordination.py
+++ b/src/pci_agent/coordination.py
@@ -53,6 +53,33 @@ class DecisionOutcome(StrEnum):
     ERROR = "error"
 
 
+class ServiceRequestStatus(StrEnum):
+    """Lifecycle state of a user-to-business service request."""
+
+    PENDING = "pending"
+    VERIFICATION_REQUIRED = "verification_required"
+    VERIFIED = "verified"
+    COMPLETED = "completed"
+    DENIED = "denied"
+    REJECTED = "rejected"
+
+
+class ServiceRequest(BaseModel):
+    """A user-to-business service request tracked by the coordinator."""
+
+    id: str
+    user_id: str
+    user_name: str
+    business_id: str
+    service_type: str
+    service_name: str
+    status: ServiceRequestStatus = ServiceRequestStatus.PENDING
+    created_at: datetime
+    expires_at: datetime
+    verification_request_id: str | None = None
+    completed_at: datetime | None = None
+
+
 class VerificationClaim(BaseModel):
     """The claim a business asks the user to prove (e.g. age >= 18)."""
 

--- a/src/pci_agent/coordination.py
+++ b/src/pci_agent/coordination.py
@@ -75,9 +75,21 @@ class ServiceRequest(BaseModel):
     service_name: str
     status: ServiceRequestStatus = ServiceRequestStatus.PENDING
     created_at: datetime
+    # Advisory for clients only; not enforced anywhere (parity with the legacy
+    # server, which stamped an expiry on service requests but never read it).
     expires_at: datetime
     verification_request_id: str | None = None
     completed_at: datetime | None = None
+
+
+class CreateServiceRequest(BaseModel):
+    """Inbound payload for POST /service-requests."""
+
+    user_id: str
+    user_name: str
+    business_id: str
+    service_type: str
+    service_name: str
 
 
 class VerificationClaim(BaseModel):

--- a/src/pci_agent/errors.py
+++ b/src/pci_agent/errors.py
@@ -21,3 +21,11 @@ class ZKPUnavailable(ServiceError):  # noqa: N818
 
 class RequestExpired(ServiceError):  # noqa: N818
     """An action was attempted on a request past its expiry."""
+
+
+class ServiceRequestNotFound(ServiceError):  # noqa: N818
+    """A referenced service request is not tracked."""
+
+
+class ServiceRequestConflict(ServiceError):  # noqa: N818
+    """The service request's status does not allow the attempted action."""

--- a/src/pci_agent/services/service_requests.py
+++ b/src/pci_agent/services/service_requests.py
@@ -1,0 +1,45 @@
+"""Service-request lifecycle rules.
+
+A service request's status is driven by its linked verification request:
+creating one moves the service request to verification_required, and the
+verification outcome maps onto the service request via service_status_for.
+
+Deliberate deviations from the legacy agent, which updated the linked
+service request unconditionally:
+
+- An ERROR verification outcome leaves the service request unchanged (the
+  legacy server recorded it as rejected, conflating a service outage with
+  the user failing the claim's criteria). The business can re-request
+  verification instead.
+- Only a service request that is pending or awaiting verification accepts a
+  new verification request; resolved ones no longer regress to
+  verification_required.
+"""
+
+from __future__ import annotations
+
+from pci_agent.coordination import RequestStatus, ServiceRequestStatus
+
+LINKABLE_STATUSES = (
+    ServiceRequestStatus.PENDING,
+    ServiceRequestStatus.VERIFICATION_REQUIRED,
+)
+
+_RESOLUTION_MAP = {
+    RequestStatus.APPROVED: ServiceRequestStatus.VERIFIED,
+    RequestStatus.REJECTED: ServiceRequestStatus.REJECTED,
+    RequestStatus.DENIED: ServiceRequestStatus.DENIED,
+}
+
+
+def service_status_for(resolution: RequestStatus) -> ServiceRequestStatus | None:
+    """Map a verification outcome onto the linked service request's status.
+
+    Args:
+        resolution: The verification request's status after evaluation.
+
+    Returns:
+        The status the linked service request should move to, or None when
+        the outcome leaves it unchanged (pending, escalated, or error).
+    """
+    return _RESOLUTION_MAP.get(resolution)

--- a/src/pci_agent/services/service_requests.py
+++ b/src/pci_agent/services/service_requests.py
@@ -1,4 +1,4 @@
-"""Service-request lifecycle rules.
+"""Service-request lifecycle orchestration.
 
 A service request's status is driven by its linked verification request:
 creating one moves the service request to verification_required, and the
@@ -14,11 +14,26 @@ service request unconditionally:
 - Only a service request that is pending or awaiting verification accepts a
   new verification request; resolved ones no longer regress to
   verification_required.
+- Only the verification request the service request currently links to may
+  drive its status; a stale, re-requested verification is ignored.
 """
 
 from __future__ import annotations
 
-from pci_agent.coordination import RequestStatus, ServiceRequestStatus
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from pci_agent.coordination import (
+    CreateServiceRequest,
+    RequestStatus,
+    ServiceRequest,
+    ServiceRequestStatus,
+    VerificationRequest,
+)
+from pci_agent.errors import ServiceRequestConflict, ServiceRequestNotFound
+from pci_agent.store import ServiceRequestRepository
+
+SERVICE_REQUEST_TTL = timedelta(minutes=10)
 
 LINKABLE_STATUSES = (
     ServiceRequestStatus.PENDING,
@@ -43,3 +58,113 @@ def service_status_for(resolution: RequestStatus) -> ServiceRequestStatus | None
         the outcome leaves it unchanged (pending, escalated, or error).
     """
     return _RESOLUTION_MAP.get(resolution)
+
+
+def create(repo: ServiceRequestRepository, payload: CreateServiceRequest) -> ServiceRequest:
+    """Create and store a pending service request.
+
+    Args:
+        repo: The service-request store.
+        payload: The requesting user's and target business's details.
+
+    Returns:
+        The stored request, pending with an advisory expiry.
+    """
+    now = datetime.now(UTC)
+    request = ServiceRequest(
+        id=uuid.uuid4().hex,
+        user_id=payload.user_id,
+        user_name=payload.user_name,
+        business_id=payload.business_id,
+        service_type=payload.service_type,
+        service_name=payload.service_name,
+        created_at=now,
+        expires_at=now + SERVICE_REQUEST_TTL,
+    )
+    repo.add(request)
+    return request
+
+
+def link_verification(repo: ServiceRequestRepository, verification: VerificationRequest) -> None:
+    """Attach a new verification request to the service request it references.
+
+    Args:
+        repo: The service-request store.
+        verification: The verification request being created; a None
+            service_request_id makes this a no-op.
+
+    Raises:
+        ServiceRequestNotFound: If the referenced service request is not
+            tracked.
+        ServiceRequestConflict: If the referenced service request has
+            already been resolved.
+    """
+    if verification.service_request_id is None:
+        return
+    request = repo.get(verification.service_request_id)
+    if request is None:
+        raise ServiceRequestNotFound("service request not found")
+    if request.status not in LINKABLE_STATUSES:
+        raise ServiceRequestConflict("service request already resolved")
+    repo.replace(
+        request.model_copy(
+            update={
+                "status": ServiceRequestStatus.VERIFICATION_REQUIRED,
+                "verification_request_id": verification.id,
+            }
+        )
+    )
+
+
+def apply_verification_outcome(
+    repo: ServiceRequestRepository, verification: VerificationRequest
+) -> None:
+    """Propagate a verification outcome to the linked service request.
+
+    Args:
+        repo: The service-request store.
+        verification: The verification request after resolution.
+    """
+    if verification.service_request_id is None:
+        return
+    request = repo.get(verification.service_request_id)
+    if request is None or request.verification_request_id != verification.id:
+        return
+    new_status = service_status_for(verification.status)
+    if new_status is None or request.status is new_status:
+        return
+    repo.replace(request.model_copy(update={"status": new_status}))
+
+
+def complete(repo: ServiceRequestRepository, request_id: str) -> ServiceRequest:
+    """Complete a verified service request.
+
+    Completing an already-completed request is idempotent and returns it
+    unchanged, because the business app polls this operation.
+
+    Args:
+        repo: The service-request store.
+        request_id: The service request to complete.
+
+    Returns:
+        The completed request.
+
+    Raises:
+        ServiceRequestNotFound: If the service request is not tracked.
+        ServiceRequestConflict: If the service request is not verified.
+    """
+    request = repo.get(request_id)
+    if request is None:
+        raise ServiceRequestNotFound("service request not found")
+    if request.status is ServiceRequestStatus.COMPLETED:
+        return request
+    if request.status is not ServiceRequestStatus.VERIFIED:
+        raise ServiceRequestConflict("service request not verified")
+    request = request.model_copy(
+        update={
+            "status": ServiceRequestStatus.COMPLETED,
+            "completed_at": datetime.now(UTC),
+        }
+    )
+    repo.replace(request)
+    return request

--- a/src/pci_agent/status.py
+++ b/src/pci_agent/status.py
@@ -45,6 +45,16 @@ class StatusClient:
         cardano_url: str,
         client: httpx2.AsyncClient | None = None,
     ) -> None:
+        """Configure the probe targets.
+
+        Args:
+            agent_url: The agent's own base URL, reported as-is.
+            zkp_url: Base URL of the ZKP service; its /health route is probed.
+            cardano_url: Base URL of the Cardano devnet API.
+            client: HTTP client override (injected in tests). When omitted, an
+                owned client with a 5-second timeout is created and closed by
+                aclose.
+        """
         self._agent_url = agent_url
         self._zkp_url = zkp_url
         self._cardano_url = cardano_url
@@ -61,6 +71,7 @@ class StatusClient:
         )
 
     async def _check_zkp(self) -> EndpointStatus:
+        """Probe the ZKP service's health route."""
         try:
             payload = await self._get_json(f"{self._zkp_url}/health")
         except (httpx2.HTTPError, ValueError) as exc:
@@ -69,6 +80,11 @@ class StatusClient:
         return EndpointStatus(status=str(status), url=self._zkp_url)
 
     async def _check_cardano(self) -> CardanoStatus:
+        """Probe the Cardano devnet's latest block.
+
+        The block number field differs across Yaci Store versions (number vs
+        height), so both are tried before giving up on the block.
+        """
         try:
             payload = await self._get_json(f"{self._cardano_url}/api/v1/blocks/latest")
         except (httpx2.HTTPError, ValueError) as exc:
@@ -80,6 +96,7 @@ class StatusClient:
         return CardanoStatus(status="healthy", url=self._cardano_url, latest_block=block)
 
     async def _get_json(self, url: str) -> object:
+        """Fetch a URL and decode its JSON body, raising on any failure."""
         response = await self._client.get(url)
         response.raise_for_status()
         return response.json()

--- a/src/pci_agent/status.py
+++ b/src/pci_agent/status.py
@@ -91,8 +91,10 @@ class StatusClient:
             return CardanoStatus(status="unavailable", url=self._cardano_url, error=_reason(exc))
         block = None
         if isinstance(payload, dict):
-            raw = payload.get("number") or payload.get("height")
-            block = raw if isinstance(raw, int) else None
+            raw = payload.get("number")
+            if raw is None:
+                raw = payload.get("height")
+            block = raw if isinstance(raw, int) and not isinstance(raw, bool) else None
         return CardanoStatus(status="healthy", url=self._cardano_url, latest_block=block)
 
     async def _get_json(self, url: str) -> object:

--- a/src/pci_agent/status.py
+++ b/src/pci_agent/status.py
@@ -1,0 +1,95 @@
+"""Reachability checks for the services the agent coordinates.
+
+Backs the /services aggregate: the agent itself plus the ZKP service and
+the Cardano devnet API, probed concurrently with a short timeout.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx2
+from pydantic import BaseModel
+
+
+class EndpointStatus(BaseModel):
+    """Reachability of one coordinated service."""
+
+    status: str
+    url: str
+    error: str | None = None
+
+
+class CardanoStatus(EndpointStatus):
+    """Cardano devnet reachability, with the latest block height when available."""
+
+    latest_block: int | None = None
+
+
+class ServicesStatus(BaseModel):
+    """Aggregate status of the agent and the services it coordinates."""
+
+    agent: EndpointStatus
+    zkp: EndpointStatus
+    cardano: CardanoStatus
+
+
+class StatusClient:
+    """Probes the health of the services the agent depends on."""
+
+    def __init__(
+        self,
+        *,
+        agent_url: str,
+        zkp_url: str,
+        cardano_url: str,
+        client: httpx2.AsyncClient | None = None,
+    ) -> None:
+        self._agent_url = agent_url
+        self._zkp_url = zkp_url
+        self._cardano_url = cardano_url
+        self._owns_client = client is None
+        self._client = client or httpx2.AsyncClient(timeout=5.0)
+
+    async def check(self) -> ServicesStatus:
+        """Probe the coordinated services concurrently and aggregate the results."""
+        zkp, cardano = await asyncio.gather(self._check_zkp(), self._check_cardano())
+        return ServicesStatus(
+            agent=EndpointStatus(status="healthy", url=self._agent_url),
+            zkp=zkp,
+            cardano=cardano,
+        )
+
+    async def _check_zkp(self) -> EndpointStatus:
+        try:
+            payload = await self._get_json(f"{self._zkp_url}/health")
+        except (httpx2.HTTPError, ValueError) as exc:
+            return EndpointStatus(status="unavailable", url=self._zkp_url, error=_reason(exc))
+        status = payload.get("status", "healthy") if isinstance(payload, dict) else "healthy"
+        return EndpointStatus(status=str(status), url=self._zkp_url)
+
+    async def _check_cardano(self) -> CardanoStatus:
+        try:
+            payload = await self._get_json(f"{self._cardano_url}/api/v1/blocks/latest")
+        except (httpx2.HTTPError, ValueError) as exc:
+            return CardanoStatus(status="unavailable", url=self._cardano_url, error=_reason(exc))
+        block = None
+        if isinstance(payload, dict):
+            raw = payload.get("number") or payload.get("height")
+            block = raw if isinstance(raw, int) else None
+        return CardanoStatus(status="healthy", url=self._cardano_url, latest_block=block)
+
+    async def _get_json(self, url: str) -> object:
+        response = await self._client.get(url)
+        response.raise_for_status()
+        return response.json()
+
+    async def aclose(self) -> None:
+        """Close the underlying client if this instance owns it."""
+        if self._owns_client:
+            await self._client.aclose()
+
+
+def _reason(exc: Exception) -> str:
+    """Render a probe failure for the status payload."""
+    return str(exc) or "unreachable"

--- a/src/pci_agent/store.py
+++ b/src/pci_agent/store.py
@@ -6,7 +6,7 @@ the service layer.
 
 from __future__ import annotations
 
-from pci_agent.coordination import VerificationRequest
+from pci_agent.coordination import ServiceRequest, VerificationRequest
 
 
 class RequestRepository:
@@ -29,4 +29,27 @@ class RequestRepository:
 
     def replace(self, req: VerificationRequest) -> None:
         """Overwrite an existing request with the same id."""
+        self._items[req.id] = req
+
+
+class ServiceRequestRepository:
+    """Stores service requests keyed by id."""
+
+    def __init__(self) -> None:
+        self._items: dict[str, ServiceRequest] = {}
+
+    def add(self, req: ServiceRequest) -> None:
+        """Store a new service request."""
+        self._items[req.id] = req
+
+    def get(self, request_id: str) -> ServiceRequest | None:
+        """Return the service request with this id, or None if absent."""
+        return self._items.get(request_id)
+
+    def list(self) -> list[ServiceRequest]:
+        """Return all stored service requests."""
+        return list(self._items.values())
+
+    def replace(self, req: ServiceRequest) -> None:
+        """Overwrite an existing service request with the same id."""
         self._items[req.id] = req

--- a/tests/test_service_flow.py
+++ b/tests/test_service_flow.py
@@ -1,5 +1,6 @@
 """Tests for the restored /services and /service-requests routes."""
 
+import pytest
 from fastapi.testclient import TestClient
 
 from pci_agent.api import create_app
@@ -13,7 +14,7 @@ from pci_agent.coordination import (
     VerificationRequest,
 )
 from pci_agent.services.service_requests import service_status_for
-from pci_agent.status import CardanoStatus, EndpointStatus, ServicesStatus
+from pci_agent.status import CardanoStatus, EndpointStatus, ServicesStatus, StatusClient
 
 
 class StubService:
@@ -84,6 +85,20 @@ def _verification_payload(service_request_id: str | None = None) -> dict[str, ob
     if service_request_id is not None:
         payload["service_request_id"] = service_request_id
     return payload
+
+
+def test_lifespan_closes_owned_status_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    closed: list[StatusClient] = []
+
+    async def record_aclose(self: StatusClient) -> None:
+        closed.append(self)
+
+    monkeypatch.setattr(StatusClient, "aclose", record_aclose)
+    config = AgentConfig(approval=ApprovalConfig(mode=ApprovalMode.MANUAL))
+    app = create_app(config, service_factory=lambda: StubService(DecisionOutcome.APPROVE))
+    with TestClient(app):
+        pass
+    assert len(closed) == 1
 
 
 def test_services_returns_status_aggregate() -> None:

--- a/tests/test_service_flow.py
+++ b/tests/test_service_flow.py
@@ -1,0 +1,290 @@
+"""Tests for the restored /services and /service-requests routes."""
+
+from fastapi.testclient import TestClient
+
+from pci_agent.api import create_app
+from pci_agent.config import AgentConfig, ApprovalConfig
+from pci_agent.coordination import (
+    ApprovalDecision,
+    ApprovalMode,
+    DecisionOutcome,
+    RequestStatus,
+    ServiceRequestStatus,
+)
+from pci_agent.services.service_requests import service_status_for
+from pci_agent.status import CardanoStatus, EndpointStatus, ServicesStatus
+
+
+class StubService:
+    def __init__(
+        self, outcome: DecisionOutcome, approve_outcome: DecisionOutcome | None = None
+    ) -> None:
+        self._outcome = outcome
+        self._approve_outcome = approve_outcome if approve_outcome is not None else outcome
+
+    async def decide(self, request):
+        return ApprovalDecision(outcome=self._outcome, reason="stub", proof={"ok": True})
+
+    async def approve(self, request):
+        return ApprovalDecision(
+            outcome=self._approve_outcome, reason="stub-approve", proof={"ok": True}
+        )
+
+
+class RaisingService:
+    async def decide(self, request):
+        raise RuntimeError("boom")
+
+    async def approve(self, request):
+        raise RuntimeError("boom")
+
+
+class StubStatusSource:
+    async def check(self) -> ServicesStatus:
+        return ServicesStatus(
+            agent=EndpointStatus(status="healthy", url="http://localhost:8082"),
+            zkp=EndpointStatus(status="healthy", url="http://zkp"),
+            cardano=CardanoStatus(status="healthy", url="http://cardano", latest_block=42),
+        )
+
+
+def _client(
+    mode: ApprovalMode = ApprovalMode.MANUAL,
+    service: StubService | RaisingService | None = None,
+) -> TestClient:
+    config = AgentConfig(approval=ApprovalConfig(mode=mode))
+    factory = None if service is None else (lambda: service)
+    app = create_app(config, service_factory=factory, status_source=StubStatusSource())
+    return TestClient(app)
+
+
+def _service_payload() -> dict:
+    return {
+        "user_id": "demo-user",
+        "user_name": "Alice Demo",
+        "business_id": "demo-business",
+        "service_type": "purchase",
+        "service_name": "Purchase Alcohol",
+    }
+
+
+def _verification_payload(service_request_id: str | None = None) -> dict:
+    payload = {
+        "business_id": "biz",
+        "business_name": "Biz",
+        "claim": {"type": "age", "params": {"minAge": 18}},
+    }
+    if service_request_id is not None:
+        payload["service_request_id"] = service_request_id
+    return payload
+
+
+def test_services_returns_status_aggregate():
+    client = _client()
+    body = client.get("/services").json()
+    assert body["agent"]["status"] == "healthy"
+    assert body["zkp"]["status"] == "healthy"
+    assert body["cardano"]["latest_block"] == 42
+
+
+def test_create_service_request_is_pending_with_full_uuid():
+    client = _client()
+    resp = client.post("/service-requests", json=_service_payload())
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["status"] == "pending"
+    assert body["verification_request_id"] is None
+    assert len(body["id"]) == 32
+    assert all(c in "0123456789abcdef" for c in body["id"])
+
+
+def test_list_service_requests_filters_by_status():
+    client = _client()
+    client.post("/service-requests", json=_service_payload())
+    client.post("/service-requests", json=_service_payload())
+
+    listed = client.get("/service-requests").json()["requests"]
+    assert len(listed) == 2
+
+    pending = client.get("/service-requests", params={"status": "pending"}).json()["requests"]
+    assert len(pending) == 2
+    verified = client.get("/service-requests", params={"status": "verified"}).json()["requests"]
+    assert verified == []
+
+
+def test_get_service_request_by_id():
+    client = _client()
+    created = client.post("/service-requests", json=_service_payload()).json()
+    resp = client.get(f"/service-requests/{created['id']}")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == created["id"]
+
+
+def test_get_missing_service_request_returns_404():
+    client = _client()
+    assert client.get("/service-requests/nope").status_code == 404
+
+
+def test_linked_verification_marks_verification_required():
+    client = _client()
+    service_req = client.post("/service-requests", json=_service_payload()).json()
+    verification = client.post(
+        "/requests", json=_verification_payload(service_req["id"])
+    ).json()
+
+    updated = client.get(f"/service-requests/{service_req['id']}").json()
+    assert updated["status"] == "verification_required"
+    assert updated["verification_request_id"] == verification["id"]
+
+
+def test_linked_verification_unknown_service_request_returns_404():
+    client = _client()
+    resp = client.post("/requests", json=_verification_payload("nope"))
+    assert resp.status_code == 404
+
+
+def test_approve_marks_service_request_verified():
+    client = _client(service=StubService(DecisionOutcome.APPROVE))
+    service_req = client.post("/service-requests", json=_service_payload()).json()
+    verification = client.post(
+        "/requests", json=_verification_payload(service_req["id"])
+    ).json()
+
+    resp = client.post(f"/requests/{verification['id']}/approve")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "approved"
+
+    updated = client.get(f"/service-requests/{service_req['id']}").json()
+    assert updated["status"] == "verified"
+
+
+def test_approve_unverified_proof_marks_service_request_rejected():
+    client = _client(
+        service=StubService(DecisionOutcome.APPROVE, approve_outcome=DecisionOutcome.REJECT)
+    )
+    service_req = client.post("/service-requests", json=_service_payload()).json()
+    verification = client.post(
+        "/requests", json=_verification_payload(service_req["id"])
+    ).json()
+
+    client.post(f"/requests/{verification['id']}/approve")
+    updated = client.get(f"/service-requests/{service_req['id']}").json()
+    assert updated["status"] == "rejected"
+
+
+def test_deny_marks_service_request_denied():
+    client = _client(service=StubService(DecisionOutcome.APPROVE))
+    service_req = client.post("/service-requests", json=_service_payload()).json()
+    verification = client.post(
+        "/requests", json=_verification_payload(service_req["id"])
+    ).json()
+
+    client.post(f"/requests/{verification['id']}/deny")
+    updated = client.get(f"/service-requests/{service_req['id']}").json()
+    assert updated["status"] == "denied"
+
+
+def test_autonomous_approval_marks_service_request_verified_on_create():
+    client = _client(
+        mode=ApprovalMode.FULLY_AUTONOMOUS, service=StubService(DecisionOutcome.APPROVE)
+    )
+    service_req = client.post("/service-requests", json=_service_payload()).json()
+    resp = client.post("/requests", json=_verification_payload(service_req["id"]))
+    assert resp.json()["status"] == "approved"
+
+    updated = client.get(f"/service-requests/{service_req['id']}").json()
+    assert updated["status"] == "verified"
+
+
+def test_evaluation_error_leaves_service_request_awaiting_verification():
+    client = _client(mode=ApprovalMode.FULLY_AUTONOMOUS, service=RaisingService())
+    service_req = client.post("/service-requests", json=_service_payload()).json()
+    resp = client.post("/requests", json=_verification_payload(service_req["id"]))
+    assert resp.status_code == 500
+
+    updated = client.get(f"/service-requests/{service_req['id']}").json()
+    assert updated["status"] == "verification_required"
+
+
+def test_complete_verified_service_request():
+    client = _client(service=StubService(DecisionOutcome.APPROVE))
+    service_req = client.post("/service-requests", json=_service_payload()).json()
+    verification = client.post(
+        "/requests", json=_verification_payload(service_req["id"])
+    ).json()
+    client.post(f"/requests/{verification['id']}/approve")
+
+    resp = client.post(f"/service-requests/{service_req['id']}/complete")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "completed"
+    assert body["completed_at"] is not None
+
+
+def test_repeat_complete_is_idempotent():
+    client = _client(service=StubService(DecisionOutcome.APPROVE))
+    service_req = client.post("/service-requests", json=_service_payload()).json()
+    verification = client.post(
+        "/requests", json=_verification_payload(service_req["id"])
+    ).json()
+    client.post(f"/requests/{verification['id']}/approve")
+
+    first = client.post(f"/service-requests/{service_req['id']}/complete")
+    second = client.post(f"/service-requests/{service_req['id']}/complete")
+    assert second.status_code == 200
+    assert second.json() == first.json()
+
+
+def test_complete_unverified_service_request_returns_409():
+    client = _client()
+    service_req = client.post("/service-requests", json=_service_payload()).json()
+    resp = client.post(f"/service-requests/{service_req['id']}/complete")
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "service request not verified"
+
+
+def test_complete_missing_service_request_returns_404():
+    client = _client()
+    assert client.post("/service-requests/nope/complete").status_code == 404
+
+
+def test_linked_verification_on_completed_service_request_returns_409():
+    client = _client(service=StubService(DecisionOutcome.APPROVE))
+    service_req = client.post("/service-requests", json=_service_payload()).json()
+    verification = client.post(
+        "/requests", json=_verification_payload(service_req["id"])
+    ).json()
+    client.post(f"/requests/{verification['id']}/approve")
+    client.post(f"/service-requests/{service_req['id']}/complete")
+
+    resp = client.post("/requests", json=_verification_payload(service_req["id"]))
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "service request already resolved"
+
+    updated = client.get(f"/service-requests/{service_req['id']}").json()
+    assert updated["status"] == "completed"
+
+
+def test_stale_verification_does_not_drive_relinked_service_request():
+    client = _client(service=StubService(DecisionOutcome.APPROVE))
+    service_req = client.post("/service-requests", json=_service_payload()).json()
+    first = client.post("/requests", json=_verification_payload(service_req["id"])).json()
+    second = client.post("/requests", json=_verification_payload(service_req["id"])).json()
+
+    client.post(f"/requests/{first['id']}/deny")
+    updated = client.get(f"/service-requests/{service_req['id']}").json()
+    assert updated["status"] == "verification_required"
+    assert updated["verification_request_id"] == second["id"]
+
+    client.post(f"/requests/{second['id']}/approve")
+    updated = client.get(f"/service-requests/{service_req['id']}").json()
+    assert updated["status"] == "verified"
+
+
+def test_service_status_for_leaves_unresolved_outcomes_unmapped():
+    assert service_status_for(RequestStatus.APPROVED) is ServiceRequestStatus.VERIFIED
+    assert service_status_for(RequestStatus.REJECTED) is ServiceRequestStatus.REJECTED
+    assert service_status_for(RequestStatus.DENIED) is ServiceRequestStatus.DENIED
+    assert service_status_for(RequestStatus.PENDING) is None
+    assert service_status_for(RequestStatus.ESCALATED) is None
+    assert service_status_for(RequestStatus.ERROR) is None

--- a/tests/test_service_flow.py
+++ b/tests/test_service_flow.py
@@ -10,36 +10,43 @@ from pci_agent.coordination import (
     DecisionOutcome,
     RequestStatus,
     ServiceRequestStatus,
+    VerificationRequest,
 )
 from pci_agent.services.service_requests import service_status_for
 from pci_agent.status import CardanoStatus, EndpointStatus, ServicesStatus
 
 
 class StubService:
+    """Approval decider returning fixed outcomes."""
+
     def __init__(
         self, outcome: DecisionOutcome, approve_outcome: DecisionOutcome | None = None
     ) -> None:
         self._outcome = outcome
         self._approve_outcome = approve_outcome if approve_outcome is not None else outcome
 
-    async def decide(self, request):
+    async def decide(self, request: VerificationRequest) -> ApprovalDecision:
         return ApprovalDecision(outcome=self._outcome, reason="stub", proof={"ok": True})
 
-    async def approve(self, request):
+    async def approve(self, request: VerificationRequest) -> ApprovalDecision:
         return ApprovalDecision(
             outcome=self._approve_outcome, reason="stub-approve", proof={"ok": True}
         )
 
 
 class RaisingService:
-    async def decide(self, request):
+    """Approval decider whose evaluation always raises an unexpected error."""
+
+    async def decide(self, request: VerificationRequest) -> ApprovalDecision:
         raise RuntimeError("boom")
 
-    async def approve(self, request):
+    async def approve(self, request: VerificationRequest) -> ApprovalDecision:
         raise RuntimeError("boom")
 
 
 class StubStatusSource:
+    """Status source returning a fixed healthy aggregate."""
+
     async def check(self) -> ServicesStatus:
         return ServicesStatus(
             agent=EndpointStatus(status="healthy", url="http://localhost:8082"),
@@ -58,7 +65,7 @@ def _client(
     return TestClient(app)
 
 
-def _service_payload() -> dict:
+def _service_payload() -> dict[str, str]:
     return {
         "user_id": "demo-user",
         "user_name": "Alice Demo",
@@ -68,8 +75,8 @@ def _service_payload() -> dict:
     }
 
 
-def _verification_payload(service_request_id: str | None = None) -> dict:
-    payload = {
+def _verification_payload(service_request_id: str | None = None) -> dict[str, object]:
+    payload: dict[str, object] = {
         "business_id": "biz",
         "business_name": "Biz",
         "claim": {"type": "age", "params": {"minAge": 18}},
@@ -79,7 +86,7 @@ def _verification_payload(service_request_id: str | None = None) -> dict:
     return payload
 
 
-def test_services_returns_status_aggregate():
+def test_services_returns_status_aggregate() -> None:
     client = _client()
     body = client.get("/services").json()
     assert body["agent"]["status"] == "healthy"
@@ -87,7 +94,7 @@ def test_services_returns_status_aggregate():
     assert body["cardano"]["latest_block"] == 42
 
 
-def test_create_service_request_is_pending_with_full_uuid():
+def test_create_service_request_is_pending_with_full_uuid() -> None:
     client = _client()
     resp = client.post("/service-requests", json=_service_payload())
     assert resp.status_code == 201
@@ -98,7 +105,7 @@ def test_create_service_request_is_pending_with_full_uuid():
     assert all(c in "0123456789abcdef" for c in body["id"])
 
 
-def test_list_service_requests_filters_by_status():
+def test_list_service_requests_filters_by_status() -> None:
     client = _client()
     client.post("/service-requests", json=_service_payload())
     client.post("/service-requests", json=_service_payload())
@@ -112,7 +119,7 @@ def test_list_service_requests_filters_by_status():
     assert verified == []
 
 
-def test_get_service_request_by_id():
+def test_get_service_request_by_id() -> None:
     client = _client()
     created = client.post("/service-requests", json=_service_payload()).json()
     resp = client.get(f"/service-requests/{created['id']}")
@@ -120,35 +127,31 @@ def test_get_service_request_by_id():
     assert resp.json()["id"] == created["id"]
 
 
-def test_get_missing_service_request_returns_404():
+def test_get_missing_service_request_returns_404() -> None:
     client = _client()
     assert client.get("/service-requests/nope").status_code == 404
 
 
-def test_linked_verification_marks_verification_required():
+def test_linked_verification_marks_verification_required() -> None:
     client = _client()
     service_req = client.post("/service-requests", json=_service_payload()).json()
-    verification = client.post(
-        "/requests", json=_verification_payload(service_req["id"])
-    ).json()
+    verification = client.post("/requests", json=_verification_payload(service_req["id"])).json()
 
     updated = client.get(f"/service-requests/{service_req['id']}").json()
     assert updated["status"] == "verification_required"
     assert updated["verification_request_id"] == verification["id"]
 
 
-def test_linked_verification_unknown_service_request_returns_404():
+def test_linked_verification_unknown_service_request_returns_404() -> None:
     client = _client()
     resp = client.post("/requests", json=_verification_payload("nope"))
     assert resp.status_code == 404
 
 
-def test_approve_marks_service_request_verified():
+def test_approve_marks_service_request_verified() -> None:
     client = _client(service=StubService(DecisionOutcome.APPROVE))
     service_req = client.post("/service-requests", json=_service_payload()).json()
-    verification = client.post(
-        "/requests", json=_verification_payload(service_req["id"])
-    ).json()
+    verification = client.post("/requests", json=_verification_payload(service_req["id"])).json()
 
     resp = client.post(f"/requests/{verification['id']}/approve")
     assert resp.status_code == 200
@@ -158,33 +161,29 @@ def test_approve_marks_service_request_verified():
     assert updated["status"] == "verified"
 
 
-def test_approve_unverified_proof_marks_service_request_rejected():
+def test_approve_unverified_proof_marks_service_request_rejected() -> None:
     client = _client(
         service=StubService(DecisionOutcome.APPROVE, approve_outcome=DecisionOutcome.REJECT)
     )
     service_req = client.post("/service-requests", json=_service_payload()).json()
-    verification = client.post(
-        "/requests", json=_verification_payload(service_req["id"])
-    ).json()
+    verification = client.post("/requests", json=_verification_payload(service_req["id"])).json()
 
     client.post(f"/requests/{verification['id']}/approve")
     updated = client.get(f"/service-requests/{service_req['id']}").json()
     assert updated["status"] == "rejected"
 
 
-def test_deny_marks_service_request_denied():
+def test_deny_marks_service_request_denied() -> None:
     client = _client(service=StubService(DecisionOutcome.APPROVE))
     service_req = client.post("/service-requests", json=_service_payload()).json()
-    verification = client.post(
-        "/requests", json=_verification_payload(service_req["id"])
-    ).json()
+    verification = client.post("/requests", json=_verification_payload(service_req["id"])).json()
 
     client.post(f"/requests/{verification['id']}/deny")
     updated = client.get(f"/service-requests/{service_req['id']}").json()
     assert updated["status"] == "denied"
 
 
-def test_autonomous_approval_marks_service_request_verified_on_create():
+def test_autonomous_approval_marks_service_request_verified_on_create() -> None:
     client = _client(
         mode=ApprovalMode.FULLY_AUTONOMOUS, service=StubService(DecisionOutcome.APPROVE)
     )
@@ -196,7 +195,7 @@ def test_autonomous_approval_marks_service_request_verified_on_create():
     assert updated["status"] == "verified"
 
 
-def test_evaluation_error_leaves_service_request_awaiting_verification():
+def test_evaluation_error_leaves_service_request_awaiting_verification() -> None:
     client = _client(mode=ApprovalMode.FULLY_AUTONOMOUS, service=RaisingService())
     service_req = client.post("/service-requests", json=_service_payload()).json()
     resp = client.post("/requests", json=_verification_payload(service_req["id"]))
@@ -206,12 +205,10 @@ def test_evaluation_error_leaves_service_request_awaiting_verification():
     assert updated["status"] == "verification_required"
 
 
-def test_complete_verified_service_request():
+def test_complete_verified_service_request() -> None:
     client = _client(service=StubService(DecisionOutcome.APPROVE))
     service_req = client.post("/service-requests", json=_service_payload()).json()
-    verification = client.post(
-        "/requests", json=_verification_payload(service_req["id"])
-    ).json()
+    verification = client.post("/requests", json=_verification_payload(service_req["id"])).json()
     client.post(f"/requests/{verification['id']}/approve")
 
     resp = client.post(f"/service-requests/{service_req['id']}/complete")
@@ -221,12 +218,10 @@ def test_complete_verified_service_request():
     assert body["completed_at"] is not None
 
 
-def test_repeat_complete_is_idempotent():
+def test_repeat_complete_is_idempotent() -> None:
     client = _client(service=StubService(DecisionOutcome.APPROVE))
     service_req = client.post("/service-requests", json=_service_payload()).json()
-    verification = client.post(
-        "/requests", json=_verification_payload(service_req["id"])
-    ).json()
+    verification = client.post("/requests", json=_verification_payload(service_req["id"])).json()
     client.post(f"/requests/{verification['id']}/approve")
 
     first = client.post(f"/service-requests/{service_req['id']}/complete")
@@ -235,7 +230,7 @@ def test_repeat_complete_is_idempotent():
     assert second.json() == first.json()
 
 
-def test_complete_unverified_service_request_returns_409():
+def test_complete_unverified_service_request_returns_409() -> None:
     client = _client()
     service_req = client.post("/service-requests", json=_service_payload()).json()
     resp = client.post(f"/service-requests/{service_req['id']}/complete")
@@ -243,17 +238,15 @@ def test_complete_unverified_service_request_returns_409():
     assert resp.json()["detail"] == "service request not verified"
 
 
-def test_complete_missing_service_request_returns_404():
+def test_complete_missing_service_request_returns_404() -> None:
     client = _client()
     assert client.post("/service-requests/nope/complete").status_code == 404
 
 
-def test_linked_verification_on_completed_service_request_returns_409():
+def test_linked_verification_on_completed_service_request_returns_409() -> None:
     client = _client(service=StubService(DecisionOutcome.APPROVE))
     service_req = client.post("/service-requests", json=_service_payload()).json()
-    verification = client.post(
-        "/requests", json=_verification_payload(service_req["id"])
-    ).json()
+    verification = client.post("/requests", json=_verification_payload(service_req["id"])).json()
     client.post(f"/requests/{verification['id']}/approve")
     client.post(f"/service-requests/{service_req['id']}/complete")
 
@@ -265,7 +258,7 @@ def test_linked_verification_on_completed_service_request_returns_409():
     assert updated["status"] == "completed"
 
 
-def test_stale_verification_does_not_drive_relinked_service_request():
+def test_stale_verification_does_not_drive_relinked_service_request() -> None:
     client = _client(service=StubService(DecisionOutcome.APPROVE))
     service_req = client.post("/service-requests", json=_service_payload()).json()
     first = client.post("/requests", json=_verification_payload(service_req["id"])).json()
@@ -281,7 +274,7 @@ def test_stale_verification_does_not_drive_relinked_service_request():
     assert updated["status"] == "verified"
 
 
-def test_service_status_for_leaves_unresolved_outcomes_unmapped():
+def test_service_status_for_leaves_unresolved_outcomes_unmapped() -> None:
     assert service_status_for(RequestStatus.APPROVED) is ServiceRequestStatus.VERIFIED
     assert service_status_for(RequestStatus.REJECTED) is ServiceRequestStatus.REJECTED
     assert service_status_for(RequestStatus.DENIED) is ServiceRequestStatus.DENIED

--- a/tests/test_status_client.py
+++ b/tests/test_status_client.py
@@ -1,9 +1,13 @@
+"""Tests for the /services status aggregation client."""
+
+from collections.abc import Callable
+
 import httpx2
 
 from pci_agent.status import StatusClient
 
 
-def _client(handler) -> StatusClient:
+def _client(handler: Callable[[httpx2.Request], httpx2.Response]) -> StatusClient:
     transport = httpx2.MockTransport(handler)
     http = httpx2.AsyncClient(transport=transport)
     return StatusClient(
@@ -14,7 +18,7 @@ def _client(handler) -> StatusClient:
     )
 
 
-async def test_check_reports_healthy_services_and_latest_block():
+async def test_check_reports_healthy_services_and_latest_block() -> None:
     def handler(request: httpx2.Request) -> httpx2.Response:
         if request.url.host == "zkp":
             return httpx2.Response(200, json={"status": "healthy"})
@@ -29,7 +33,7 @@ async def test_check_reports_healthy_services_and_latest_block():
     await client.aclose()
 
 
-async def test_check_reports_unavailable_on_transport_error():
+async def test_check_reports_unavailable_on_transport_error() -> None:
     def handler(request: httpx2.Request) -> httpx2.Response:
         raise httpx2.ConnectError("refused")
 
@@ -42,7 +46,7 @@ async def test_check_reports_unavailable_on_transport_error():
     await client.aclose()
 
 
-async def test_check_reports_unavailable_on_http_error_status():
+async def test_check_reports_unavailable_on_http_error_status() -> None:
     def handler(request: httpx2.Request) -> httpx2.Response:
         return httpx2.Response(500)
 
@@ -53,7 +57,7 @@ async def test_check_reports_unavailable_on_http_error_status():
     await client.aclose()
 
 
-async def test_check_uses_cardano_height_fallback():
+async def test_check_uses_cardano_height_fallback() -> None:
     def handler(request: httpx2.Request) -> httpx2.Response:
         if request.url.host == "zkp":
             return httpx2.Response(200, json={})
@@ -66,7 +70,7 @@ async def test_check_uses_cardano_height_fallback():
     await client.aclose()
 
 
-async def test_check_tolerates_non_numeric_block():
+async def test_check_tolerates_non_numeric_block() -> None:
     def handler(request: httpx2.Request) -> httpx2.Response:
         if request.url.host == "zkp":
             return httpx2.Response(200, json={"status": "healthy"})

--- a/tests/test_status_client.py
+++ b/tests/test_status_client.py
@@ -70,6 +70,19 @@ async def test_check_uses_cardano_height_fallback() -> None:
     await client.aclose()
 
 
+async def test_check_reports_block_zero_without_height_fallback() -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        if request.url.host == "zkp":
+            return httpx2.Response(200, json={"status": "healthy"})
+        return httpx2.Response(200, json={"number": 0, "height": 5})
+
+    client = _client(handler)
+    result = await client.check()
+    assert result.cardano.status == "healthy"
+    assert result.cardano.latest_block == 0
+    await client.aclose()
+
+
 async def test_check_tolerates_non_numeric_block() -> None:
     def handler(request: httpx2.Request) -> httpx2.Response:
         if request.url.host == "zkp":

--- a/tests/test_status_client.py
+++ b/tests/test_status_client.py
@@ -1,0 +1,79 @@
+import httpx2
+
+from pci_agent.status import StatusClient
+
+
+def _client(handler) -> StatusClient:
+    transport = httpx2.MockTransport(handler)
+    http = httpx2.AsyncClient(transport=transport)
+    return StatusClient(
+        agent_url="http://agent",
+        zkp_url="http://zkp",
+        cardano_url="http://cardano",
+        client=http,
+    )
+
+
+async def test_check_reports_healthy_services_and_latest_block():
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        if request.url.host == "zkp":
+            return httpx2.Response(200, json={"status": "healthy"})
+        return httpx2.Response(200, json={"number": 123})
+
+    client = _client(handler)
+    result = await client.check()
+    assert result.agent.status == "healthy"
+    assert result.zkp.status == "healthy"
+    assert result.cardano.status == "healthy"
+    assert result.cardano.latest_block == 123
+    await client.aclose()
+
+
+async def test_check_reports_unavailable_on_transport_error():
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        raise httpx2.ConnectError("refused")
+
+    client = _client(handler)
+    result = await client.check()
+    assert result.zkp.status == "unavailable"
+    assert result.zkp.error
+    assert result.cardano.status == "unavailable"
+    assert result.cardano.latest_block is None
+    await client.aclose()
+
+
+async def test_check_reports_unavailable_on_http_error_status():
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(500)
+
+    client = _client(handler)
+    result = await client.check()
+    assert result.zkp.status == "unavailable"
+    assert result.cardano.status == "unavailable"
+    await client.aclose()
+
+
+async def test_check_uses_cardano_height_fallback():
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        if request.url.host == "zkp":
+            return httpx2.Response(200, json={})
+        return httpx2.Response(200, json={"height": 7})
+
+    client = _client(handler)
+    result = await client.check()
+    assert result.zkp.status == "healthy"
+    assert result.cardano.latest_block == 7
+    await client.aclose()
+
+
+async def test_check_tolerates_non_numeric_block():
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        if request.url.host == "zkp":
+            return httpx2.Response(200, json={"status": "healthy"})
+        return httpx2.Response(200, json={"number": "not-a-block"})
+
+    client = _client(handler)
+    result = await client.check()
+    assert result.cardano.status == "healthy"
+    assert result.cardano.latest_block is None
+    await client.aclose()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -52,14 +52,14 @@ def _service_req(request_id: str) -> ServiceRequest:
     )
 
 
-def test_service_request_add_and_get():
+def test_service_request_add_and_get() -> None:
     repo = ServiceRequestRepository()
     repo.add(_service_req("a"))
     assert repo.get("a").id == "a"
     assert repo.get("missing") is None
 
 
-def test_service_request_replace_updates_in_place():
+def test_service_request_replace_updates_in_place() -> None:
     repo = ServiceRequestRepository()
     repo.add(_service_req("a"))
     updated = repo.get("a").model_copy(update={"status": ServiceRequestStatus.VERIFIED})

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -2,10 +2,12 @@ from datetime import UTC, datetime
 
 from pci_agent.coordination import (
     RequestStatus,
+    ServiceRequest,
+    ServiceRequestStatus,
     VerificationClaim,
     VerificationRequest,
 )
-from pci_agent.store import RequestRepository
+from pci_agent.store import RequestRepository, ServiceRequestRepository
 
 
 def _req(request_id: str) -> VerificationRequest:
@@ -33,4 +35,34 @@ def test_replace_updates_in_place():
     updated = repo.get("a").model_copy(update={"status": RequestStatus.APPROVED})
     repo.replace(updated)
     assert repo.get("a").status is RequestStatus.APPROVED
+    assert len(repo.list()) == 1
+
+
+def _service_req(request_id: str) -> ServiceRequest:
+    now = datetime.now(UTC)
+    return ServiceRequest(
+        id=request_id,
+        user_id="user",
+        user_name="User",
+        business_id="biz",
+        service_type="purchase",
+        service_name="Purchase Alcohol",
+        created_at=now,
+        expires_at=now,
+    )
+
+
+def test_service_request_add_and_get():
+    repo = ServiceRequestRepository()
+    repo.add(_service_req("a"))
+    assert repo.get("a").id == "a"
+    assert repo.get("missing") is None
+
+
+def test_service_request_replace_updates_in_place():
+    repo = ServiceRequestRepository()
+    repo.add(_service_req("a"))
+    updated = repo.get("a").model_copy(update={"status": ServiceRequestStatus.VERIFIED})
+    repo.replace(updated)
+    assert repo.get("a").status is ServiceRequestStatus.VERIFIED
     assert len(repo.list()) == 1


### PR DESCRIPTION
Fixes #17

Restores the coordination endpoints dropped by the FastAPI migration (#20), as thin FastAPI routes over service/repository layers with pydantic models.

## Endpoints

- `GET /services` — status aggregate of agent / ZKP / Cardano (probed concurrently, 5s timeout)
- `GET /service-requests` (with optional `?status=` filter, as legacy had), `GET /service-requests/{id}`, `POST /service-requests`
- `POST /service-requests/{id}/complete`
- `POST /requests` (existing) now honors `service_request_id`: it links the verification request and drives the service-request lifecycle

## Issue-text vs. legacy reality: no service catalogue ever existed

Issue #17 describes `GET /services` + `POST /services` as a "service catalogue". Recovering the legacy stdlib `http.server` implementation (`src/pci_agent/__main__.py` at `3867186^`) shows:

- Legacy `GET /services` was a **live status aggregate** (`{agent, zkp, cardano}` with `latestBlock`), which is exactly what pci-demo's status bar consumes.
- **`POST /services` never existed in any historical version** (verified with `git log -S 'POST /services'` across all revisions), and there was no catalogue of any kind.

So this PR keeps `GET /services` as the status aggregate (semantics preserved, response now snake_case) and deliberately does **not** invent a `POST /services`. If a real service catalogue is wanted, it deserves its own design/issue rather than a phantom port. `GET /service-requests/{id}` existed in legacy but was omitted from the issue's list; it is restored for resource completeness.

## New-contract conventions (breaking vs. legacy, per #17's consumer-side reconciliation plan)

- snake_case fields (`user_id`, `latest_block`, `verification_request_id`, …), required creation fields (no silent defaults)
- Full-UUID hex ids (32 chars) instead of legacy `uuid4[:8]`
- FastAPI `{"detail": ...}` errors; 404 for unknown ids, 409 for state conflicts (legacy used `{"error": ...}` and 400)

## Lifecycle semantics (preserved from legacy)

`pending → verification_required` (verification request created with `service_request_id`) `→ verified | rejected | denied` (verification approved-with-proof / proof-failed / user-denied) `→ completed` (business calls complete on a verified request). Escalated/pending verification outcomes leave the service request awaiting verification, matching the legacy manual flow.

## Deliberate deviations from legacy (flagged, not blindly replicated)

1. **Verification ERROR no longer marks the service request `rejected`.** Legacy conflated a ZKP/context outage with "user failed the criteria". Now the service request stays `verification_required` and the business can re-request verification.
2. **Linking guards.** Legacy silently ignored an unknown `serviceRequestId` and unconditionally regressed *any* service request (even completed ones) back to `verification_required`. Now: unknown id → 404; already resolved (verified/completed/denied/rejected) → 409; only `pending`/`verification_required` accept a (re-)link.
3. **Stale-verification guard.** Only the verification request the service request currently links to may drive its status; a superseded verification's later outcome is ignored.
4. **Repeat completion is idempotent** — `POST /service-requests/{id}/complete` returns 200 with the unchanged request when already completed (pci-demo's business app calls this from a 2s polling loop; legacy returned 400). Any other unverified state is 409.
5. **`expires_at` on service requests is advisory** (documented on the model): legacy stamped a 10-minute expiry but never read it anywhere, and this port preserves that — no expiry enforcement, no eviction. Enforcing it would be a behavior change beyond the port; happy to do it as a follow-up if wanted.

## Verification

- 206 tests pass (`uv run pytest`), incl. new TestClient suites for every route: 404s, 409s, repeat-completion idempotency, stale-link, autonomous + manual modes, ERROR path; `uv run pre-commit run --all-files` and `uv run mypy src/pci_agent` (strict) clean.
- Exercised live with curl against `uv run python -m pci_agent` plus stub ZKP/Cardano HTTP services: `/services` aggregate (incl. `latest_block`), full deny path (`pending → verification_required → denied`), complete on non-verified → 409, unknown ids → 404, link-to-resolved → 409. The verified→completed path (incl. idempotent repeat) was exercised over live HTTP with the approval seam stubbed, because the packaged Phase 1 `ContextClient` never connects — a real approve currently resolves to `error` ("private data unavailable") on `main` too, which is pre-existing and out of scope here.
- pci-demo run with `VITE_ENABLE_SERVICE_FLOW=true` against the live agent: initial `GET /requests`, `GET /service-requests`, `GET /services` all succeed (status-bar dots work), but the flag-on path still speaks the legacy camelCase contract — `POST /service-requests` with `userId`/`userName`/… is a 422, and the status bar reads `latestBlock` where the agent now returns `latest_block`. That consumer-side reconciliation is tracked in the follow-up pci-demo issue, per #17's plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added service health reporting for the agent, ZKP service and Cardano.
  - Added service request creation, listing and retrieval.
  - Added request lifecycle tracking from verification through approval, denial and completion.
  - Added safeguards for invalid, missing, expired or already completed requests.
  - Added idempotent completion for requests that have already been completed.

- **Bug Fixes**
  - Improved error responses for missing resources and conflicting service-request states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->